### PR TITLE
Fix multi-level domain validation

### DIFF
--- a/htdocs/js/bulk-manager.js
+++ b/htdocs/js/bulk-manager.js
@@ -120,9 +120,9 @@
             // Remove protocols and www
             var cleanUrl = url.replace(/^https?:\/\//, '').replace(/^www\./, '');
             
-            // Basic domain validation regex
-            var domainRegex = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]?\.[a-zA-Z]{2,}$/;
-            
+            // Basic domain validation regex - allow multi-level domains
+            var domainRegex = /^([a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]?\.)+[a-zA-Z]{2,}$/;
+
             return domainRegex.test(cleanUrl.split('/')[0]);
         },
         


### PR DESCRIPTION
## Summary
- fix JS regex so multi-level domain names like `example.co.uk` validate correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859ecb1256c832f9275ba9dd480f02d